### PR TITLE
Don't allow empty feature names

### DIFF
--- a/lib/featurer/adapters/redis.rb
+++ b/lib/featurer/adapters/redis.rb
@@ -36,7 +36,8 @@ module Featurer
     end
 
     def register(feature, value = true)
-      # ensure old data is wiped
+      return if feature.nil? || feature.empty?
+
       delete(feature)
       save_set(feature, value)
     end

--- a/spec/lib/featurer/adapters/redis_spec.rb
+++ b/spec/lib/featurer/adapters/redis_spec.rb
@@ -75,4 +75,38 @@ describe Featurer::RedisAdapter do
       end
     end
   end
+
+  describe '#register' do
+    shared_examples 'rejected feature' do
+      it "doesn't register the feature" do
+        expect(subject).not_to receive(:delete)
+        expect(subject).not_to receive(:save_set)
+
+        subject.register(feature)
+      end
+    end
+
+    context 'feature name is not empty' do
+      let(:feature) { 'awesome_feature' }
+
+      it 'registers the feature' do
+        expect(subject).to receive(:delete).with(feature)
+        expect(subject).to receive(:save_set).with(feature, true)
+
+        subject.register(feature)
+      end
+    end
+
+    context 'feature name is empty' do
+      let(:feature) { '' }
+
+      it_behaves_like 'rejected feature'
+    end
+
+    context 'feature name is nil' do
+      let(:feature) { nil }
+
+      it_behaves_like 'rejected feature'
+    end
+  end
 end


### PR DESCRIPTION
`Featurer.register(nil)` and `Featurer.register("")` were making the entire `Featurer` thing break.

Therefor I think we shouldn't allow empty feature names. Problem fixed.