### PR TITLE
Don't allow empty feature names

### DIFF
--- a/lib/featurer/adapters/redis.rb
+++ b/lib/featurer/adapters/redis.rb
@@ -36,7 +36,8 @@ module Featurer
     end
 
     def register(feature, value = true)
-      # ensure old data is wiped
+      return if feature.nil? || feature.empty?
+
       delete(feature)
       save_set(feature, value)
     end

--- a/lib/featurer/adapters/redis.rb
+++ b/lib/featurer/adapters/redis.rb
@@ -41,13 +41,16 @@ module Featurer
       save_set(feature, value)
     end
 
-    private
-
-    def all_features
-      @redis.keys("#{@config[:prefix]}:feature:*").map do |key|
-        key.split("#{@config[:prefix]}:feature:").last.to_sym
+    def feature_list
+      full_feature_names.map do |full_feature_name|
+        {
+          name: short_feature_name(full_feature_name),
+          matching_values: @redis.smembers(full_feature_name)
+        }
       end
     end
+
+    private
 
     def key(name)
       "#{@config[:prefix]}:feature:#{name}"
@@ -79,6 +82,20 @@ module Featurer
 
     def remove_from_set(name, id)
       @redis.srem(key(name), id)
+    end
+
+    def all_features
+      full_feature_names.map do |key|
+        short_feature_name(key)
+      end
+    end
+
+    def full_feature_names
+      @redis.keys("#{@config[:prefix]}:feature:*")
+    end
+
+    def short_feature_name(full_feature_name)
+      full_feature_name.split("#{@config[:prefix]}:feature:").last.to_sym
     end
   end
 end

--- a/spec/lib/featurer/adapters/redis_spec.rb
+++ b/spec/lib/featurer/adapters/redis_spec.rb
@@ -75,4 +75,38 @@ describe Featurer::RedisAdapter do
       end
     end
   end
+
+  describe '#register' do
+    shared_examples 'rejected feature' do
+      it "doesn't register the feature" do
+        expect(subject).not_to receive(:delete)
+        expect(subject).not_to receive(:save_set)
+
+        subject.register(feature)
+      end
+    end
+
+    context 'feature name is not empty' do
+      let(:feature) { 'awesome_feature' }
+
+      it 'registers the feature' do
+        expect(subject).to receive(:delete).with(feature)
+        expect(subject).to receive(:save_set).with(feature, true)
+
+        subject.register(feature)
+      end
+    end
+
+    context 'feature name is empty' do
+      let(:feature) { '' }
+
+      it_behaves_like 'rejected feature'
+    end
+
+    context 'feature name is nil' do
+      let(:feature) { nil }
+
+      it_behaves_like 'rejected feature'
+    end
+  end
 end


### PR DESCRIPTION
This is the code originally posted by @uesteibar in #3.

I didn't notice it was made against this branch, which got merged before #3 was merged.